### PR TITLE
feat: Added initial code of conduct

### DIFF
--- a/src/assets/code_of_conduct.md
+++ b/src/assets/code_of_conduct.md
@@ -1,0 +1,93 @@
+<p align="center">
+  <img width="300" height="300" src="./event-logo.svg">
+</p>
+
+<p align="center">
+
+  # Code of Conduct
+</p>
+
+Purpose
+-------
+
+A primary goal of [GDG Chicago](https://www.meetup.com/Google-Developers-Group-GDG-Chicago/) is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. We are committed to providing a friendly, safe, and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof). GDG Chicago prides itself on being an open, respectful, and inclusive community. That means [jerky behavior](https://meta.wikimedia.org/wiki/Don%27t_be_a_jerk) isn’t allowed.
+
+This goal and policy is applied to any and all events ran by GDG Chicago, including Windy City DevFest 2019. All attendees are expected to comply in full to this policy.
+
+This Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior. We invite all those who participate in Google Developers Group to help us create safe and positive experiences for everyone. We also include ways for DevFest attendees to report any violations. Together we can make Windy City DevFest a fun harassment-free conference experience for everyone, regardless of gender, gender identity, sexual orientation, disability, physical appearance, body size, race, or religion.
+
+Open [Source/Culture/Tech] Citizenship
+--------------------------------------
+A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community. Communities mirror the societies in which they exist, and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society. If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+Expected Behavior
+-----------------
+The following behaviors are expected and requested of all community members:
+
+- Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community. 
+- Exercise consideration and respect in your speech and actions. 
+- Attempt collaboration before a conflict. 
+- Refrain from demeaning, discriminatory, or harassing behavior and speech. 
+- Be mindful of your surroundings and your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential. 
+
+Unacceptable Behavior
+---------------------
+The following actions are considered harassment and are unacceptable within our community:
+
+- Violence, threats of violence or violent language directed against another person. 
+- Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language. 
+- Posting or displaying sexually explicit or violent material. 
+- Posting or threatening to post other people’s personally identifying information ("doxing"). 
+- Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability. 
+- Inappropriate photography or recording. 
+- Inappropriate physical contact. You should have someone’s consent before touching them. 
+- Unwelcome sexual attention. This includes sexualized comments or jokes; inappropriate touching, groping, and unwelcome sexual advances. 
+- Deliberate intimidation, stalking or following (online or in person). 
+- Advocating for, or encouraging, any of the above behavior. 
+- Sustained disruption of community events, including talks and, presentations. 
+
+Consequences of Unacceptable Behavior
+-------------------------------------
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated. 
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If a community member engages in unacceptable behavior, Windy City DevFest organizers may take any action they deem appropriate, up to and including a warning, temporary ban, or permanent expulsion from the community/event without warning (and without refund in the case of a paid event).
+
+Reporting
+---------
+If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible. Conference staff can be identified by special lanyards and/or special badges. Conference staff is also located at the registration desk throughout the duration of the event. Harassment and other code of conduct violations reduce the value of our event for everyone. We want you to be happy at our event. People like you make our event a better place.
+
+You can make a report either personally or anonymously.
+
+Anonymous Report
+----------------
+You can make an anonymous report here:
+
+[https://bit.ly/2RstTJ8](https://bit.ly/2RstTJ8)
+
+We can't follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.
+
+Personal Report
+---------------
+You can make a personal report by getting in contact with any of the event organizers. Event Organizers can be identified by special lanyards and/or special badges. If you wish, you can also use the anonymous form but provide your contact information at the end. In the event organizers are not able to be reached, please reach out to us directly by phone/email at:
+
+- General GDG/DevFest Organizer: – ([chicagogdg@gmail.com](mailto:chicagogdg@gmail.com))
+- GDG Co-Organizer: Joel Vasallo – 773 318 8144 ([joelvasallo@gmail.com](mailto:joelvasallo@gmail.com))
+- Lead Organizer/GDG Mentor: Dan Baran – 630 212 1540 ([danbaran@gmail.com](mailto:danbaran@gmail.com))
+- Women Techmakers Lead/GDG Co-Organizer: Deana Greenfield – ([deanagreenfield@gmail.com](mailto:deanagreenfield@gmail.com))
+- GDG North America Program Manager: Kyle Paul
+- Emergency: 911 
+- ICASA Hotline (24/7): (888) 293-2080 
+
+When taking a personal report, our staff will ensure you are safe and cannot be overheard. They may involve other event staff to ensure your report is managed properly. Once safe, we'll ask you to tell us about what happened. This can be upsetting, but we'll handle it as respectfully as possible, and you can bring someone to support you. You won't be asked to confront anyone, and we won't tell anyone who you are.
+
+Our team will be happy to help you contact hotel/venue security, local law enforcement, local support services, provide escorts, or otherwise assist you to feel safe for the duration of the event. We value your attendance.
+
+Scope
+-----
+We expect all community participants to abide by this Code of Conduct in all community venues – online and in-person – as well as in all one-on-one communications about community business. This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to affect the safety and well-being of community members adversely.
+
+License
+-------
+This Code of Conduct was forked from the example policy from the [Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), created by the Ada Initiative and other volunteers. which is under a Creative Commons Zero license.
+
+Conference Code of Conduct is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
- Missing contact of two as we work on consent

Headers might be off and maybe logo can be fixed but this has content parity of our old PDF code of Conduct. :)